### PR TITLE
AP_RangeFinder Elevate signal_quality to the backend state structure.

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -220,6 +220,7 @@ void RangeFinder::init(enum Rotation orientation_default)
         // initialise status
         state[i].status = Status::NotConnected;
         state[i].range_valid_count = 0;
+        state[i].signal_quality_pct = SIGNAL_QUALITY_NODATA;
     }
 }
 
@@ -693,6 +694,15 @@ uint16_t RangeFinder::distance_cm_orient(enum Rotation orientation) const
     return distance_orient(orientation) * 100.0;
 }
 
+int8_t RangeFinder::signal_quality_pct_orient(enum Rotation orientation) const
+{
+    AP_RangeFinder_Backend *backend = find_instance(orientation);
+    if (backend == nullptr) {
+        return RangeFinder::SIGNAL_QUALITY_NODATA;
+    }
+    return backend->signal_quality_pct();
+}
+
 int16_t RangeFinder::max_distance_cm_orient(enum Rotation orientation) const
 {
     AP_RangeFinder_Backend *backend = find_instance(orientation);
@@ -793,10 +803,6 @@ void RangeFinder::Log_RFND() const
             continue;
         }
 
-        int8_t signal_quality;
-        if (!s->get_signal_quality_pct(signal_quality)) {
-          signal_quality = -1;
-        }
         const struct log_RFND pkt = {
                 LOG_PACKET_HEADER_INIT(LOG_RFND_MSG),
                 time_us      : AP_HAL::micros64(),
@@ -804,7 +810,7 @@ void RangeFinder::Log_RFND() const
                 dist         : s->distance_cm(),
                 status       : (uint8_t)s->status(),
                 orient       : s->orientation(),
-                quality      : signal_quality,
+                quality      : s->signal_quality_pct(),
         };
         AP::logger().WriteBlock(&pkt, sizeof(pkt));
     }

--- a/libraries/AP_RangeFinder/AP_RangeFinder.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.h
@@ -193,9 +193,14 @@ public:
         Good
     };
 
+    static constexpr int8_t SIGNAL_QUALITY_MIN = 0;
+    static constexpr int8_t SIGNAL_QUALITY_MAX = 100;
+    static constexpr int8_t SIGNAL_QUALITY_NODATA = -1;
+
     // The RangeFinder_State structure is filled in by the backend driver
     struct RangeFinder_State {
         float distance_m;               // distance in meters
+        int8_t signal_quality_pct;      // measurement quality in percent 0-100, -1 -> no quality available
         uint16_t voltage_mv;            // voltage in millivolts, if applicable, otherwise 0
         enum RangeFinder::Status status; // sensor status
         uint8_t  range_valid_count;     // number of consecutive valid readings (maxes out at 10)
@@ -260,6 +265,7 @@ public:
     // any sensor which can current supply it
     float distance_orient(enum Rotation orientation) const;
     uint16_t distance_cm_orient(enum Rotation orientation) const;
+    int8_t signal_quality_pct_orient(enum Rotation orientation) const;
     int16_t max_distance_cm_orient(enum Rotation orientation) const;
     int16_t min_distance_cm_orient(enum Rotation orientation) const;
     int16_t ground_clearance_cm_orient(enum Rotation orientation) const;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_BLPing.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_BLPing.cpp
@@ -86,6 +86,7 @@ bool AP_RangeFinder_BLPing::get_reading(float &reading_m)
 bool AP_RangeFinder_BLPing::get_signal_quality_pct(int8_t &quality_pct) const
 {
     if (status() != RangeFinder::Status::Good) {
+        quality_pct = RangeFinder::SIGNAL_QUALITY_MIN;
         return false;
     }
     quality_pct = protocol.get_confidence();

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
@@ -48,6 +48,7 @@ public:
     enum Rotation orientation() const { return (Rotation)params.orientation.get(); }
     float distance() const { return state.distance_m; }
     uint16_t distance_cm() const { return state.distance_m*100.0f; }
+    int8_t signal_quality_pct() const { return state.signal_quality_pct; }
     uint16_t voltage_mv() const { return state.voltage_mv; }
     virtual int16_t max_distance_cm() const { return params.max_distance_cm; }
     virtual int16_t min_distance_cm() const { return params.min_distance_cm; }
@@ -71,10 +72,6 @@ public:
 
     // get temperature reading in C.  returns true on success and populates temp argument
     virtual bool get_temp(float &temp) const { return false; }
-
-    // 0 is no return value, 100 is perfect.  false means signal
-    // quality is not available
-    virtual bool get_signal_quality_pct(int8_t &quality_pct) const { return false; }
 
     // return the actual type of the rangefinder, as opposed to the
     // parameter value which may be changed at runtime.

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Backend_Serial.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Backend_Serial.cpp
@@ -56,6 +56,10 @@ void AP_RangeFinder_Backend_Serial::update(void)
         // update range_valid state based on distance measured
         state.last_reading_ms = AP_HAL::millis();
         update_status();
+        // update signal_quality_pct
+        if (!get_signal_quality_pct(state.signal_quality_pct)) {
+            state.signal_quality_pct = RangeFinder::SIGNAL_QUALITY_NODATA;
+        }
     } else if (AP_HAL::millis() - state.last_reading_ms > read_timeout_ms()) {
         set_status(RangeFinder::Status::NoData);
     }

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Backend_Serial.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Backend_Serial.h
@@ -31,4 +31,9 @@ protected:
 
     // maximum time between readings before we change state to NoData:
     virtual uint16_t read_timeout_ms() const { return 200; }
+
+    // 0 is no return value, 100 is perfect.  false means signal_quality
+    // is not available and quality_pct set to SIGNAL_QUALITY_NODATA.
+    virtual bool get_signal_quality_pct(int8_t &quality_pct) const WARN_IF_UNUSED
+    { quality_pct = RangeFinder::SIGNAL_QUALITY_NODATA; return false; }
 };

--- a/libraries/AP_RangeFinder/AP_RangeFinder_MAVLink.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_MAVLink.cpp
@@ -79,19 +79,12 @@ void AP_RangeFinder_MAVLink::update(void)
     if (AP_HAL::millis() - state.last_reading_ms > AP_RANGEFINDER_MAVLINK_TIMEOUT_MS) {
         set_status(RangeFinder::Status::NoData);
         state.distance_m = 0.0f;
+        state.signal_quality_pct = RangeFinder::SIGNAL_QUALITY_NODATA;
     } else {
         state.distance_m = distance_cm * 0.01f;
+        state.signal_quality_pct = signal_quality;
         update_status();
     }
-}
-
-bool AP_RangeFinder_MAVLink::get_signal_quality_pct(int8_t &quality_pct) const
-{
-    if (status() != RangeFinder::Status::Good) {
-        return false;
-    }
-    quality_pct = signal_quality;
-    return true;
 }
 
 #endif

--- a/libraries/AP_RangeFinder/AP_RangeFinder_MAVLink.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_MAVLink.h
@@ -31,10 +31,6 @@ public:
     int16_t max_distance_cm() const override;
     int16_t min_distance_cm() const override;
 
-    // Get the reading confidence
-    // 100 is best quality, 0 is worst
-    WARN_IF_UNUSED bool get_signal_quality_pct(int8_t &quality_pct) const override;
-
 protected:
 
     MAV_DISTANCE_SENSOR _get_mav_distance_sensor_type() const override {

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -385,13 +385,16 @@ void GCS_MAVLINK::send_distance_sensor(const AP_RangeFinder_Backend *sensor, con
         return;
     }
 
-    int8_t quality_pct;
+    int8_t quality_pct = sensor->signal_quality_pct();
+    // ardupilot defines this field as -1 is unknown, 0 is poor, 100 is excellent
+    // mavlink defines this field as 0 is unknown, 1 is invalid, 100 is perfect
     uint8_t quality;
-    if (sensor->get_signal_quality_pct(quality_pct)) {
-        // mavlink defines this field as 0 is unknown, 1 is invalid, 100 is perfect
-        quality = MAX(quality_pct, 1);
-    } else {
+    if (quality_pct == RangeFinder::SIGNAL_QUALITY_NODATA) {
         quality = 0;
+    } else if (quality_pct > 1 && quality_pct <= RangeFinder::SIGNAL_QUALITY_MAX) {
+        quality = quality_pct;
+    } else {
+        quality = 1;
     }
 
     mavlink_msg_distance_sensor_send(


### PR DESCRIPTION
Previously, a RangeFinder client would obtain signal_quality through a backend virtual function - get_signal_quality_pct(). That client would obtain the distance measurement from the backend state structure. The state structure is updated by a periodic update() method. Because of this delayed update, a client will often receive the current signal_quality value but an older distance measurement.

This PR moves signal_quality into the state structure so the distance measurement and its signal_quality are kept in sync.

What would be an appropriate way to test this? to autotest this?

An implementation note: the virtual method get_signal_quality_pct() was removed from class AP_RangeFinder_Backend. It was added to class AP_RangeFinder_Backend_Serial. This was done to avoid having to change the AP_RangeFinder_Backend_Serial::get_reading() interface and modify all of the serial drivers. This added virtual function is used in the AP_RangeFinder_Backend_Serial::update() method and is not available to normal RangeFinder clients.